### PR TITLE
Fix a permission error on SO and PO duplication

### DIFF
--- a/s6r_purchase_invoiced_forced_qty/models/purchase_order_line.py
+++ b/s6r_purchase_invoiced_forced_qty/models/purchase_order_line.py
@@ -7,8 +7,7 @@ class PurchaseOrderLine(models.Model):
     qty_invoiced_forced = fields.Float(
         string="Forced Billed Qty",
         help= "Qty already invoiced but not related to existing supplier invoices in Odoo (for history data import purposes)",
-        digits='Product Unit of Measure',
-        groups= "base.group_system")
+        digits='Product Unit of Measure')
 
 
     @api.depends('invoice_lines.move_id.state', 'invoice_lines.quantity', 'qty_received', 'product_uom_qty', 'order_id.state', 'qty_invoiced_forced')

--- a/s6r_purchase_invoiced_forced_qty/views/purchase_order_form_inherit.xml
+++ b/s6r_purchase_invoiced_forced_qty/views/purchase_order_form_inherit.xml
@@ -9,7 +9,8 @@
                     <field name="qty_invoiced_forced"
                            string="Billed Forced"
                            column_invisible="parent.state not in ('purchase', 'done')"
-                           optional="hide"/>
+                           optional="hide"
+                           groups="base.group_system"/>
                 </xpath>
             </field>
         </record>

--- a/s6r_sale_invoiced_forced_qty/models/sale_order_line.py
+++ b/s6r_sale_invoiced_forced_qty/models/sale_order_line.py
@@ -7,8 +7,7 @@ class SaleOrderLine(models.Model):
     qty_invoiced_forced = fields.Float(
         string="Forced Invoiced Quantity",
         help= "Qty already invoiced but not related to existing invoices in Odoo (for history data import purposes)",
-        digits='Product Unit of Measure',
-        groups= "base.group_system")
+        digits='Product Unit of Measure')
 
 
     @api.depends('invoice_lines.move_id.state', 'invoice_lines.quantity', 'qty_invoiced_forced')

--- a/s6r_sale_invoiced_forced_qty/views/sale_order_form_inherit.xml
+++ b/s6r_sale_invoiced_forced_qty/views/sale_order_form_inherit.xml
@@ -11,7 +11,8 @@
                            decoration-bf="(not display_type and invoice_status == 'to invoice')"
                            string="Invoiced Forced"
                            column_invisible="parent.state != 'sale'"
-                           optional="hide"/>
+                           optional="hide"
+                           groups="base.group_system"/>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
Problème rencontré:
- les utilisateurs ne possédant pas la permission "Administration/Paramètres" ne peuvent pas dupliquer un Bon de commande (app Ventes ou Achats)

Solution proposée:
- La restriction au groupe "base.group_system" était faite directement au niveau de la déclaration du champ en Python, sans que les méthodes 'oncopy' ne soient correctement adaptées afin de continuer de fonctionner. => la restriction au groupe a été supprimé du code python et intégrée directement à la vue.