### PR TITLE
17.0 fix compute purchase qty invoiced forced

### DIFF
--- a/s6r_purchase_invoiced_forced_qty/__manifest__.py
+++ b/s6r_purchase_invoiced_forced_qty/__manifest__.py
@@ -2,7 +2,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 {
     'name': 'S6R Purchase Order Invoiced Forced Qty',
-    'version': '17.0.1.0.1',
+    'version': '17.0.1.0.2',
     'author': 'Scalizer',
     'website': 'https://www.scalizer.fr',
     'summary': "This module allows to force the invoiced quantity on Purchase Orders",

--- a/s6r_purchase_invoiced_forced_qty/models/purchase_order_line.py
+++ b/s6r_purchase_invoiced_forced_qty/models/purchase_order_line.py
@@ -15,4 +15,5 @@ class PurchaseOrderLine(models.Model):
         super()._compute_qty_invoiced()
         for line in self:
             line.qty_invoiced += line.qty_invoiced_forced
+            line.qty_to_invoice -= line.qty_invoiced_forced
         return


### PR DESCRIPTION
le champ qty_to_invoice n'était pas mis à jour dans le compute, du coup les factures étaient générées avec des quantités erronées