### PR TITLE
17.0 fix views and copy attr

### DIFF
--- a/s6r_purchase_invoiced_forced_qty/__manifest__.py
+++ b/s6r_purchase_invoiced_forced_qty/__manifest__.py
@@ -2,7 +2,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 {
     'name': 'S6R Purchase Order Invoiced Forced Qty',
-    'version': '17.0.1.0.2',
+    'version': '17.0.1.0.3',
     'author': 'Scalizer',
     'website': 'https://www.scalizer.fr',
     'summary': "This module allows to force the invoiced quantity on Purchase Orders",
@@ -24,7 +24,7 @@ it is useful in customer data import scenarios where the historical supplier inv
     'images': [
     ],
     'data': [
-        'views/purchase_order_form_inherit.xml',
+        'views/purchase_order_views.xml',
         'security/ir.model.access.csv',
     ],
     'auto_install': False,

--- a/s6r_purchase_invoiced_forced_qty/i18n/fr.po
+++ b/s6r_purchase_invoiced_forced_qty/i18n/fr.po
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: s6r_purchase_invoiced_forced_qty
-#: model_terms:ir.ui.view,arch_db:s6r_purchase_invoiced_forced_qty.purchase_order_form_inherit
+#: model_terms:ir.ui.view,arch_db:s6r_purchase_invoiced_forced_qty.purchase_order_form_inherit_s6r
 msgid "Billed Forced"
 msgstr "Qté facturée (forcée)"
 

--- a/s6r_purchase_invoiced_forced_qty/models/purchase_order_line.py
+++ b/s6r_purchase_invoiced_forced_qty/models/purchase_order_line.py
@@ -7,7 +7,9 @@ class PurchaseOrderLine(models.Model):
     qty_invoiced_forced = fields.Float(
         string="Forced Billed Qty",
         help= "Qty already invoiced but not related to existing supplier invoices in Odoo (for history data import purposes)",
-        digits='Product Unit of Measure')
+        digits='Product Unit of Measure',
+        copy=False,
+    )
 
 
     @api.depends('invoice_lines.move_id.state', 'invoice_lines.quantity', 'qty_received', 'product_uom_qty', 'order_id.state', 'qty_invoiced_forced')

--- a/s6r_purchase_invoiced_forced_qty/views/purchase_order_views.xml
+++ b/s6r_purchase_invoiced_forced_qty/views/purchase_order_views.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-        <record id="purchase_order_form_inherit" model="ir.ui.view">
-            <field name="name">purchase.order.form.inherit</field>
+        <record id="purchase_order_form_inherit_s6r" model="ir.ui.view">
+            <field name="name">purchase.order.form.inherit.s6r</field>
             <field name="model">purchase.order</field>
             <field name="inherit_id" ref="purchase.purchase_order_form"/>
             <field name="arch" type="xml">

--- a/s6r_sale_invoiced_forced_qty/__manifest__.py
+++ b/s6r_sale_invoiced_forced_qty/__manifest__.py
@@ -2,7 +2,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 {
     'name': 'S6R Sale Order Invoiced Forced Qty',
-    'version': '17.0.1.0.2',
+    'version': '17.0.1.0.3',
     'author': 'Scalizer',
     'website': 'https://www.scalizer.fr',
     'summary': "This module allows to force the invoiced quantity on Sale Orders",

--- a/s6r_sale_invoiced_forced_qty/__manifest__.py
+++ b/s6r_sale_invoiced_forced_qty/__manifest__.py
@@ -24,7 +24,7 @@ it is useful in customer data import scenarios where the historical invoices are
     'images': [
     ],
     'data': [
-        'views/sale_order_form_inherit.xml',
+        'views/sale_order_views.xml',
         'security/ir.model.access.csv',
     ],
     'auto_install': False,

--- a/s6r_sale_invoiced_forced_qty/i18n/fr.po
+++ b/s6r_sale_invoiced_forced_qty/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-22 10:26+0000\n"
-"PO-Revision-Date: 2025-01-22 10:26+0000\n"
+"POT-Creation-Date: 2025-03-12 12:43+0000\n"
+"PO-Revision-Date: 2025-03-12 12:43+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -23,7 +23,9 @@ msgid ""
 "existing amount will not be taken in consideration when calculating the"
 "         total invoiced amount for the sale order. Therefore, reports "
 "relating to this sale order will be false."
-msgstr ""
+msgstr "Montant déjà facturé mais non lié à des factures existantes dans Odoo (pour l'import de données historiques)."
+"Si ce champ est laissé vide, le montant pré-existant ne sera pas pris en considération lors du calcul du"
+"montant total facturé pour la commande. Par conséquent, les rapports relatifs à cette commande seront faux."
 
 #. module: s6r_sale_invoiced_forced_qty
 #: model:ir.model.fields,field_description:s6r_sale_invoiced_forced_qty.field_sale_order_line__untaxed_amount_invoiced_forced
@@ -36,12 +38,12 @@ msgid "Forced Invoiced Quantity"
 msgstr "Quantité facturée (forcée)"
 
 #. module: s6r_sale_invoiced_forced_qty
-#: model_terms:ir.ui.view,arch_db:s6r_sale_invoiced_forced_qty.sale_order_form_inherit
+#: model_terms:ir.ui.view,arch_db:s6r_sale_invoiced_forced_qty.sale_order_form_inherit_s6r
 msgid "Invoiced Amount (forced)"
 msgstr "Montant facturé (forcé)"
 
 #. module: s6r_sale_invoiced_forced_qty
-#: model_terms:ir.ui.view,arch_db:s6r_sale_invoiced_forced_qty.sale_order_form_inherit
+#: model_terms:ir.ui.view,arch_db:s6r_sale_invoiced_forced_qty.sale_order_form_inherit_s6r
 msgid "Invoiced Qty (forced)"
 msgstr "Quantité facturée (forcée)"
 

--- a/s6r_sale_invoiced_forced_qty/models/sale_order_line.py
+++ b/s6r_sale_invoiced_forced_qty/models/sale_order_line.py
@@ -7,13 +7,16 @@ class SaleOrderLine(models.Model):
     qty_invoiced_forced = fields.Float(
         string="Forced Invoiced Quantity",
         help= "Qty already invoiced but not related to existing invoices in Odoo (for history data import purposes)",
-        digits='Product Unit of Measure')
+        digits='Product Unit of Measure',
+        copy=False,
+    )
 
     untaxed_amount_invoiced_forced = fields.Monetary(
         string="Forced Invoiced Amount",
         help="Amount already invoiced but not related to existing invoices in Odoo (for history data import purposes).\
         If this field is left blank, the pre-existing amount will not be taken in consideration when calculating the \
-        total invoiced amount for the sale order. Therefore, reports relating to this sale order will be false."
+        total invoiced amount for the sale order. Therefore, reports relating to this sale order will be false.",
+        copy=False,
     )
 
     @api.depends('qty_invoiced_forced')

--- a/s6r_sale_invoiced_forced_qty/views/sale_order_views.xml
+++ b/s6r_sale_invoiced_forced_qty/views/sale_order_views.xml
@@ -21,6 +21,10 @@
                            optional="hide"
                            groups="base.group_system"/>
                 </xpath>
+                <xpath expr="//field[@name='order_line']//field[@name='analytic_distribution']" position="after">
+                    <field name="qty_invoiced_forced" invisible="parent.state != 'sale'"/>
+                    <field name="untaxed_amount_invoiced_forced" invisible="parent.state != 'sale'"/>
+                </xpath>
             </field>
         </record>
 </odoo>

--- a/s6r_sale_invoiced_forced_qty/views/sale_order_views.xml
+++ b/s6r_sale_invoiced_forced_qty/views/sale_order_views.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-        <record id="sale_order_form_inherit" model="ir.ui.view">
-            <field name="name">sale.order.form.inherit</field>
+        <record id="sale_order_form_inherit_s6r" model="ir.ui.view">
+            <field name="name">sale.order.form.inherit.s6r</field>
             <field name="model">sale.order</field>
             <field name="inherit_id" ref="sale.view_order_form"/>
             <field name="arch" type="xml">


### PR DESCRIPTION
- renommage des fichiers de vues
-  ajout des champs custom dans la vue form des sale order line (utilisé sur le projet CGF)
- modification de l'attribut 'copy' sur les champs custom pour éviter la duplication de valeurs erronées